### PR TITLE
Refactor family section with reusable cards

### DIFF
--- a/app/components/FamilyMemberCard.module.css
+++ b/app/components/FamilyMemberCard.module.css
@@ -1,0 +1,122 @@
+.card {
+  display: flex;
+  background-color: var(--family-card-bg, #ffffff);
+  color: var(--family-card-text, #3a3a3a);
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.08);
+}
+
+.horizontal {
+  flex-direction: row;
+  min-height: 360px;
+}
+
+.vertical {
+  flex-direction: column;
+}
+
+.reverse {
+  flex-direction: row-reverse;
+}
+
+.imageWrapper {
+  position: relative;
+  flex: 1;
+  min-width: 260px;
+  min-height: 320px;
+  background-color: var(--family-sand, #d7cec0);
+}
+
+.vertical .imageWrapper {
+  width: 100%;
+  min-height: 260px;
+}
+
+.image {
+  object-fit: cover;
+  transition: transform 0.4s ease;
+}
+
+.card:hover .image {
+  transform: scale(1.05);
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(2rem, 5vw, 4rem);
+  gap: 1rem;
+  background-color: var(--family-card-content-bg, #ffffff);
+}
+
+.name {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  font-weight: 300;
+  letter-spacing: 0.04em;
+}
+
+.title {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  color: var(--family-card-light-text, #6a6a6a);
+}
+
+.accent {
+  width: 50px;
+  height: 2px;
+  background-color: var(--family-card-accent, #d7cec0);
+  margin: 1rem 0;
+}
+
+.description {
+  color: var(--family-card-light-text, #6a6a6a);
+  font-size: 1rem;
+  line-height: 1.8;
+}
+
+.description p {
+  margin: 0;
+}
+
+.description a {
+  color: var(--family-link-color, #1f4d5a);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: color 0.3s ease, border-color 0.3s ease;
+}
+
+.description a:hover,
+.description a:focus-visible {
+  color: #163742;
+  border-color: currentColor;
+  outline: none;
+}
+
+@media (max-width: 1024px) {
+  .horizontal,
+  .reverse {
+    flex-direction: column;
+  }
+
+  .imageWrapper,
+  .vertical .imageWrapper {
+    min-height: 280px;
+  }
+}
+
+@media (max-width: 768px) {
+  .content {
+    padding: 2rem;
+  }
+}

--- a/app/components/FamilyMemberCard.tsx
+++ b/app/components/FamilyMemberCard.tsx
@@ -1,0 +1,64 @@
+import Image from "next/image";
+import { ReactNode } from "react";
+
+import styles from "./FamilyMemberCard.module.css";
+
+type Orientation = "horizontal" | "vertical";
+type ImagePosition = "left" | "right";
+
+interface FamilyMemberCardProps {
+  name: string;
+  title: string;
+  description: ReactNode;
+  imageSrc: string;
+  orientation?: Orientation;
+  imagePosition?: ImagePosition;
+  className?: string;
+}
+
+export default function FamilyMemberCard({
+  name,
+  title,
+  description,
+  imageSrc,
+  orientation = "vertical",
+  imagePosition = "left",
+  className,
+}: FamilyMemberCardProps) {
+  const containerClasses = [
+    styles.card,
+    orientation === "horizontal" ? styles.horizontal : styles.vertical,
+  ];
+
+  if (orientation === "horizontal" && imagePosition === "right") {
+    containerClasses.push(styles.reverse);
+  }
+
+  if (className) {
+    containerClasses.push(className);
+  }
+
+  return (
+    <article className={containerClasses.join(" ")}>
+      <div className={styles.imageWrapper}>
+        <Image
+          src={imageSrc}
+          alt={name}
+          fill
+          sizes={
+            orientation === "horizontal"
+              ? "(min-width: 1024px) 50vw, 100vw"
+              : "(min-width: 1280px) 25vw, (min-width: 768px) 33vw, 100vw"
+          }
+          className={styles.image}
+        />
+      </div>
+      <div className={styles.content}>
+        <h3 className={styles.name}>{name}</h3>
+        <p className={styles.title}>{title}</p>
+        <div className={styles.accent} />
+        <div className={styles.description}>{description}</div>
+      </div>
+    </article>
+  );
+}

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,0 +1,354 @@
+:global(:root) {
+  --family-mint: #c8d6cf;
+  --family-sand: #d7cec0;
+  --family-white: #ffffff;
+  --family-dark-text: #3a3a3a;
+  --family-light-text: #6a6a6a;
+  --family-card-bg: var(--family-white);
+  --family-card-content-bg: var(--family-white);
+  --family-card-text: var(--family-dark-text);
+  --family-card-accent: var(--family-sand);
+  --family-link-color: #1f4d5a;
+}
+
+.page {
+  background-color: var(--family-mint);
+  min-height: 100vh;
+  font-family: "Times New Roman", serif;
+  color: var(--family-dark-text);
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+
+.languageSwitch {
+  position: fixed;
+  top: 2rem;
+  right: 2rem;
+  padding: 0.5rem 1rem;
+  background-color: rgba(255, 255, 255, 0.7);
+  border: none;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  z-index: 100;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s ease;
+}
+
+.languageSwitch:hover,
+.languageSwitch:focus-visible {
+  background-color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  outline: none;
+}
+
+.heroSection {
+  position: relative;
+  min-height: 100vh;
+  background-color: var(--family-mint);
+  overflow: hidden;
+}
+
+.heroInner {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+}
+
+.heroWrapper {
+  display: flex;
+  flex-wrap: wrap;
+  width: min(90%, 1600px);
+  margin: 0 auto;
+  min-height: 75vh;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
+}
+
+.heroImage {
+  flex: 8;
+  min-width: 300px;
+  position: relative;
+  min-height: 300px;
+  overflow: hidden;
+}
+
+.heroImage img {
+  object-fit: cover;
+}
+
+.heroContent {
+  background-color: var(--family-white);
+  flex: 5;
+  min-width: 300px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(2rem, 5vw, 5rem);
+  position: relative;
+  box-sizing: border-box;
+}
+
+.heroText {
+  position: relative;
+  padding: 2rem 0;
+}
+
+.heroTitle {
+  font-weight: 300;
+  margin: 0;
+  padding: 0;
+  border: none;
+  text-decoration: none;
+}
+
+.heroTitlePrimary {
+  display: block;
+  font-size: clamp(4rem, 6vw, 7rem);
+  font-weight: 300;
+  margin: 0 0 0.5rem;
+  line-height: 1.2;
+  color: var(--family-dark-text);
+  font-family: "造字工房朗宋", "汉仪瑞兽", "FZLangSong", "华文隶书", "LiSu", serif;
+  letter-spacing: 0.05em;
+}
+
+.heroTitleSecondary {
+  display: block;
+  font-size: clamp(2.5rem, 4vw, 4.5rem);
+  font-weight: 300;
+  opacity: 0.7;
+  color: var(--family-dark-text);
+  font-family: "Cinzel", "Trajan Pro", "Times New Roman", serif;
+  font-style: italic;
+  letter-spacing: 0.08em;
+}
+
+.heroDescription {
+  margin-top: 2rem;
+  font-size: clamp(1rem, 1.3vw, 1.3rem);
+  line-height: 1.8;
+  letter-spacing: 0.02em;
+  color: var(--family-dark-text);
+  max-width: 600px;
+}
+
+.textLink {
+  display: inline-block;
+  margin-top: 1rem;
+  color: var(--family-dark-text);
+  text-decoration: none;
+  border-bottom: 1px solid var(--family-dark-text);
+  padding-bottom: 0.25rem;
+  font-size: 0.9rem;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  transition: color 0.3s ease, border-color 0.3s ease;
+}
+
+.textLink:hover,
+.textLink:focus-visible {
+  color: var(--family-link-color);
+  border-color: var(--family-link-color);
+  outline: none;
+}
+
+.familySection {
+  padding: 15vh 0;
+}
+
+.sectionContainer {
+  width: min(90%, 1600px);
+  margin: 0 auto;
+}
+
+.sectionTitle {
+  font-size: clamp(2.5rem, 5vw, 4rem);
+  font-weight: 300;
+  margin-bottom: 5rem;
+  text-align: center;
+  color: var(--family-dark-text);
+}
+
+.familyGrid {
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: stretch;
+}
+
+.horizontalCard {
+  grid-column: 1 / -1;
+}
+
+.gallerySection {
+  margin-bottom: 5rem;
+}
+
+.galleryTitle {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 300;
+  margin-bottom: 3rem;
+  text-align: center;
+  color: var(--family-dark-text);
+}
+
+.galleryGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.galleryStatus {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 3rem 0;
+  color: var(--family-light-text);
+}
+
+.galleryItem {
+  position: relative;
+  height: 250px;
+  overflow: hidden;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+}
+
+.galleryImage {
+  object-fit: cover;
+  transition: transform 0.4s ease;
+}
+
+.galleryItem:hover .galleryImage {
+  transform: scale(1.05);
+}
+
+.galleryCta {
+  text-align: center;
+  margin-top: 3rem;
+}
+
+.footerSection {
+  background-color: var(--family-white);
+  padding: 10vh 0;
+}
+
+.footerContainer {
+  width: min(90%, 800px);
+  margin: 0 auto;
+  text-align: center;
+}
+
+.footerText {
+  font-size: 1.2rem;
+  color: var(--family-light-text);
+  line-height: 1.8;
+  margin-bottom: 0;
+}
+
+.lightboxOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.9);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  cursor: zoom-out;
+}
+
+.lightboxClose {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: transparent;
+  border: none;
+  color: #ffffff;
+  font-size: 24px;
+  cursor: pointer;
+  z-index: 1001;
+}
+
+.lightboxContent {
+  max-width: 90%;
+  max-height: 90%;
+  position: relative;
+  width: min(90vw, 1000px);
+  height: min(90vh, 80vw);
+}
+
+.lightboxImage {
+  object-fit: contain;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  cursor: default;
+}
+
+.hidden {
+  display: none;
+}
+
+.lightboxLoader {
+  color: #ffffff;
+  font-size: 1.2rem;
+  text-align: center;
+}
+
+.socialLink {
+  color: var(--family-link-color);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: color 0.3s ease, border-color 0.3s ease;
+}
+
+.socialLink:hover,
+.socialLink:focus-visible {
+  border-color: currentColor;
+  outline: none;
+}
+
+.socialLinkX {
+  color: #1da1f2;
+}
+
+.socialLinkInstagram {
+  color: #e1306c;
+}
+
+@media (max-width: 1024px) {
+  .heroInner {
+    min-height: auto;
+  }
+
+  .heroWrapper {
+    min-height: auto;
+  }
+
+  .languageSwitch {
+    top: 1.5rem;
+    right: 1.5rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .heroDescription {
+    max-width: none;
+  }
+
+  .familySection {
+    padding: 10vh 0;
+  }
+
+  .galleryItem {
+    height: 220px;
+  }
+
+  .languageSwitch {
+    top: 1rem;
+    right: 1rem;
+  }
+}

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,4 +1,4 @@
-:global(:root) {
+.page {
   --family-mint: #c8d6cf;
   --family-sand: #d7cec0;
   --family-white: #ffffff;
@@ -9,9 +9,7 @@
   --family-card-text: var(--family-dark-text);
   --family-card-accent: var(--family-sand);
   --family-link-color: #1f4d5a;
-}
 
-.page {
   background-color: var(--family-mint);
   min-height: 100vh;
   font-family: "Times New Roman", serif;

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -174,11 +174,18 @@
   display: grid;
   gap: 3rem;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  align-items: stretch;
+  align-items: start;
 }
 
 .horizontalCard {
   grid-column: 1 / -1;
+  justify-self: stretch;
+}
+
+.verticalCard {
+  width: 100%;
+  max-width: 360px;
+  justify-self: center;
 }
 
 .gallerySection {
@@ -333,6 +340,10 @@
 }
 
 @media (max-width: 768px) {
+  .verticalCard {
+    max-width: none;
+  }
+
   .heroDescription {
     max-width: none;
   }

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -183,9 +183,8 @@
 }
 
 .verticalCard {
-  width: 100%;
-  max-width: 360px;
-  justify-self: center;
+  grid-column: 1 / -1;
+  justify-self: stretch;
 }
 
 .gallerySection {
@@ -340,10 +339,6 @@
 }
 
 @media (max-width: 768px) {
-  .verticalCard {
-    max-width: none;
-  }
-
   .heroDescription {
     max-width: none;
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -317,7 +317,9 @@ export default function Home() {
       title: texts.jimmy.title[language],
       description: familyDescriptions.jimmy[language],
       imageSrc: photos.jimmy,
-      orientation: 'vertical' as const
+      orientation: 'vertical' as const,
+      imagePosition: 'left' as const,
+      className: undefined
     },
     {
       key: 'tinny',
@@ -325,7 +327,9 @@ export default function Home() {
       title: texts.tinny.title[language],
       description: familyDescriptions.tinny[language],
       imageSrc: photos.tinny,
-      orientation: 'vertical' as const
+      orientation: 'vertical' as const,
+      imagePosition: 'left' as const,
+      className: undefined
     },
     {
       key: 'kelly',
@@ -333,7 +337,9 @@ export default function Home() {
       title: texts.kelly.title[language],
       description: familyDescriptions.kelly[language],
       imageSrc: photos.kelly,
-      orientation: 'vertical' as const
+      orientation: 'vertical' as const,
+      imagePosition: 'left' as const,
+      className: undefined
     }
   ] as const;
 
@@ -350,7 +356,7 @@ export default function Home() {
         photosLoadedRef.current = true;
       } catch (error) {
         console.error('获取照片错误:', error);
-        setRandomPhotos(photos.gallery);
+        setRandomPhotos([...photos.gallery]);
         photosLoadedRef.current = true;
       } finally {
         setIsLoading(false);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,122 +2,99 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useState, useEffect, useRef } from "react";
-import { getPhotoPathsClient } from "./gallery/gallery-api";
+import { useEffect, useRef, useState } from "react";
 
-// 定义自定义事件类型
+import FamilyMemberCard from "./components/FamilyMemberCard";
+import { getPhotoPathsClient } from "./gallery/gallery-api";
+import styles from "./page.module.css";
+
+type Language = 'zh' | 'en';
+
 interface LanguageChangeEventDetail {
-  language: 'zh' | 'en';
+  language: Language;
+}
+
+interface LightboxState {
+  isOpen: boolean;
+  currentImage: string;
+  loading: boolean;
 }
 
 export default function Home() {
-  // 添加随机照片状态
   const [randomPhotos, setRandomPhotos] = useState<string[]>([]);
-  // 添加加载状态
   const [isLoading, setIsLoading] = useState(true);
-  // 添加语言状态(zh:中文，en:英文)
-  const [language, setLanguage] = useState<'zh' | 'en'>('zh');
-  
-  // 添加灯箱状态
-  const [lightbox, setLightbox] = useState({
+  const [language, setLanguage] = useState<Language>('zh');
+  const [lightbox, setLightbox] = useState<LightboxState>({
     isOpen: false,
     currentImage: '',
-    loading: true // 添加加载状态
+    loading: true
   });
-  
-  // 记录是否已经获取过照片
+
   const photosLoadedRef = useRef(false);
-  
-  // 初始化语言设置
+
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const savedLanguage = localStorage.getItem('language') as 'zh' | 'en' | null;
+      const savedLanguage = localStorage.getItem('language') as Language | null;
       if (savedLanguage) {
         setLanguage(savedLanguage);
+        document.documentElement.lang = savedLanguage === 'zh' ? 'zh-CN' : 'en';
       } else {
-        // 如果没有保存过语言设置，检测浏览器语言
         const browserLang = navigator.language.toLowerCase();
-        const preferredLang = browserLang.startsWith('zh') ? 'zh' : 'en';
+        const preferredLang: Language = browserLang.startsWith('zh') ? 'zh' : 'en';
         setLanguage(preferredLang);
         localStorage.setItem('language', preferredLang);
-        
-        // 更新HTML lang属性
         document.documentElement.lang = preferredLang === 'zh' ? 'zh-CN' : 'en';
       }
     }
   }, []);
-  
-  // 切换语言
+
   const toggleLanguage = () => {
-    const newLang = language === 'zh' ? 'en' : 'zh';
+    const newLang: Language = language === 'zh' ? 'en' : 'zh';
     setLanguage(newLang);
-    
-    // 保存到localStorage
     localStorage.setItem('language', newLang);
-    
-    // 更新HTML lang属性
     document.documentElement.lang = newLang === 'zh' ? 'zh-CN' : 'en';
-    
-    // 触发自定义事件，通知layout组件
-    const event = new CustomEvent<LanguageChangeEventDetail>('languageChange', { 
-      detail: { language: newLang } 
+
+    const event = new CustomEvent<LanguageChangeEventDetail>('languageChange', {
+      detail: { language: newLang }
     });
     window.dispatchEvent(event);
   };
-  
-  // 打开灯箱
+
   const openLightbox = (imageSrc: string) => {
     setLightbox({
       isOpen: true,
       currentImage: imageSrc,
       loading: true
     });
-    // 禁止背景滚动
     document.body.style.overflow = 'hidden';
   };
-  
-  // 关闭灯箱
+
   const closeLightbox = () => {
     setLightbox({
       isOpen: false,
       currentImage: '',
       loading: true
     });
-    // 恢复背景滚动
     document.body.style.overflow = 'auto';
   };
-  
-  // 图片加载完成
+
   const handleImageLoad = () => {
     setLightbox(prev => ({ ...prev, loading: false }));
   };
-  
-  // 从照片集合中随机选择特定数量的照片
+
   const getRandomPhotos = (photos: string[], count: number) => {
-    // 复制数组，以免修改原数组
     const photosCopy = [...photos];
-    const result = [];
-    
-    // 随机选择照片
-    for (let i = 0; i < count && photosCopy.length > 0; i++) {
+    const result: string[] = [];
+
+    for (let i = 0; i < count && photosCopy.length > 0; i += 1) {
       const randomIndex = Math.floor(Math.random() * photosCopy.length);
       result.push(photosCopy[randomIndex]);
-      photosCopy.splice(randomIndex, 1); // 移除已选照片，避免重复
+      photosCopy.splice(randomIndex, 1);
     }
-    
+
     return result;
   };
-  
-  // 柔和的配色方案
-  const colors = {
-    mint: '#c8d6cf',      // 淡薄荷绿色背景
-    sand: '#d7cec0',      // 沙色块
-    white: '#ffffff',     // 白色块
-    darkText: '#3a3a3a',  // 深色文字
-    lightText: '#6a6a6a'  // 浅色文字
-  };
 
-  // 中英文文本内容
   const texts = {
     homeIntro: {
       zh: '家，是生活最初的诗篇，是记忆长久的温暖。欢迎来到我们的家庭主页，在这里分享我们的故事、回忆和未来。',
@@ -139,10 +116,6 @@ export default function Home() {
       title: {
         zh: '家庭顶梁柱',
         en: 'Family Pillar'
-      },
-      desc: {
-        zh: '作为家庭的中流砥柱，Dash不仅关心每个家庭成员的需求，也为家庭提供坚实的依靠。他喜欢编程和技术，闲暇时会带领全家一起户外活动。在 <a href="https://x.com/DashHuang" target="_blank" rel="noopener noreferrer" style="color: #1DA1F2; text-decoration: none;">X</a> 和 <a href="https://www.instagram.com/dashhuang/" target="_blank" rel="noopener noreferrer" style="color: #E1306C; text-decoration: none;">Instagram</a> 上分享技术和生活。',
-        en: 'As the backbone of the family, Dash not only cares for the needs of each family member but also provides solid support. He enjoys programming and technology, and in his spare time, leads the family in outdoor activities. Follow him on <a href="https://x.com/DashHuang" target="_blank" rel="noopener noreferrer" style="color: #1DA1F2; text-decoration: none;">X</a> and <a href="https://www.instagram.com/dashhuang/" target="_blank" rel="noopener noreferrer" style="color: #E1306C; text-decoration: none;">Instagram</a> for tech and life.'
       }
     },
     cherry: {
@@ -153,10 +126,6 @@ export default function Home() {
       title: {
         zh: '家庭的灵魂人物',
         en: 'Soul of the Family'
-      },
-      desc: {
-        zh: 'Cherry是家庭的情感核心，善解人意且充满智慧。她热爱阅读和烹饪，总是能为家人带来美味佳肴和温暖的关怀，是孩子们心中的避风港。',
-        en: 'Cherry is the emotional core of the family, understanding and full of wisdom. She loves reading and cooking, always bringing delicious food and warm care to the family, and is a safe harbor for the children.'
       }
     },
     jimmy: {
@@ -167,10 +136,6 @@ export default function Home() {
       title: {
         zh: '大儿子',
         en: 'Eldest Son'
-      },
-      desc: {
-        zh: 'Jimmy聪明好学，对科学和自然充满好奇心。他喜欢游戏和网球，总是能带给家人欢乐和惊喜。',
-        en: 'Jimmy is intelligent and eager to learn, with curiosity about science and nature. He enjoys gaming and tennis, always bringing joy and surprises to the family.'
       }
     },
     tinny: {
@@ -181,10 +146,6 @@ export default function Home() {
       title: {
         zh: '大女儿',
         en: 'Eldest Daughter'
-      },
-      desc: {
-        zh: 'Tinny充满创造力，热爱艺术和音乐。她喜欢跳舞和钢琴，有着丰富的想象力和细腻的情感。',
-        en: 'Tinny is full of creativity, loving art and music. She enjoys dancing and playing the piano, with rich imagination and delicate emotions.'
       }
     },
     kelly: {
@@ -195,10 +156,6 @@ export default function Home() {
       title: {
         zh: '二女儿',
         en: 'Younger Daughter'
-      },
-      desc: {
-        zh: 'Kelly活泼可爱，才3岁，充满好奇心。她最喜欢和姐姐妈妈玩，总是用她天真的笑容感染着全家人。',
-        en: 'Kelly is lively and adorable, only 3 years old, full of curiosity. She loves playing with her sister and mother, always infecting the whole family with her innocent smile.'
       }
     },
     gallery: {
@@ -213,212 +170,222 @@ export default function Home() {
       zh: 'English',
       en: '中文'
     }
-  };
+  } as const;
 
-  // 选择一些照片用于不同部分
   const photos = {
-    hero: '/family-photos/719BD143-ADD6-4F94-8CFC-BAF43235608A.jpg',  // 主页照片，添加时间戳
-    dash: '/family-photos/IMG_0875.jpeg',       // Dash照片
-    cherry: '/family-photos/L1030065.JPG',     // Cherry照片
-    jimmy: '/family-photos/jimmy.jpg',      // Jimmy照片
-    tinny: '/family-photos/IMG_3908.jpeg',      // Tinny照片
-    kelly: '/family-photos/IMG_9664.jpeg',      // Kelly照片
-    gallery: [                                  // 相册照片（作为备用）
+    hero: '/family-photos/719BD143-ADD6-4F94-8CFC-BAF43235608A.jpg',
+    dash: '/family-photos/IMG_0875.jpeg',
+    cherry: '/family-photos/L1030065.JPG',
+    jimmy: '/family-photos/jimmy.jpg',
+    tinny: '/family-photos/IMG_3908.jpeg',
+    kelly: '/family-photos/IMG_9664.jpeg',
+    gallery: [
       '/family-photos/IMG_9200.jpeg',
       '/family-photos/IMG_9147.jpeg',
       '/family-photos/IMG_9139.jpeg',
       '/family-photos/IMG_9071.jpeg',
       '/family-photos/IMG_1435.jpeg',
       '/family-photos/IMG_7604.jpeg',
-      '/family-photos/2U2A5498.jpg',            // 添加新照片
-      '/family-photos/2U2A5506.jpg'             // 添加新照片
+      '/family-photos/2U2A5498.jpg',
+      '/family-photos/2U2A5506.jpg'
     ]
-  };
-  
-  // 获取照片
+  } as const;
+
+  const familyDescriptions = {
+    dash: {
+      zh: (
+        <p>
+          作为家庭的中流砥柱，Dash不仅关心每个家庭成员的需求，也为家庭提供坚实的依靠。他喜欢编程和技术，闲暇时会带领全家一起户外活动。在
+          <a
+            className={`${styles.socialLink} ${styles.socialLinkX}`}
+            href="https://x.com/DashHuang"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            X
+          </a>
+          和
+          <a
+            className={`${styles.socialLink} ${styles.socialLinkInstagram}`}
+            href="https://www.instagram.com/dashhuang/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Instagram
+          </a>
+          上分享技术和生活。
+        </p>
+      ),
+      en: (
+        <p>
+          As the backbone of the family, Dash not only cares for the needs of each family member but also provides solid support. He enjoys programming and technology, and in his spare time, leads the family in outdoor activities. Follow him on{' '}
+          <a
+            className={`${styles.socialLink} ${styles.socialLinkX}`}
+            href="https://x.com/DashHuang"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            X
+          </a>{' '}
+          and{' '}
+          <a
+            className={`${styles.socialLink} ${styles.socialLinkInstagram}`}
+            href="https://www.instagram.com/dashhuang/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Instagram
+          </a>{' '}
+          for tech and life.
+        </p>
+      )
+    },
+    cherry: {
+      zh: (
+        <p>
+          Cherry是家庭的情感核心，善解人意且充满智慧。她热爱阅读和烹饪，总是能为家人带来美味佳肴和温暖的关怀，是孩子们心中的避风港。
+        </p>
+      ),
+      en: (
+        <p>
+          Cherry is the emotional core of the family, understanding and full of wisdom. She loves reading and cooking, always bringing delicious food and warm care to the family, and is a safe harbor for the children.
+        </p>
+      )
+    },
+    jimmy: {
+      zh: (
+        <p>
+          Jimmy聪明好学，对科学和自然充满好奇心。他喜欢游戏和网球，总是能带给家人欢乐和惊喜。
+        </p>
+      ),
+      en: (
+        <p>
+          Jimmy is intelligent and eager to learn, with curiosity about science and nature. He enjoys gaming and tennis, always bringing joy and surprises to the family.
+        </p>
+      )
+    },
+    tinny: {
+      zh: (
+        <p>
+          Tinny充满创造力，热爱艺术和音乐。她喜欢跳舞和钢琴，有着丰富的想象力和细腻的情感。
+        </p>
+      ),
+      en: (
+        <p>
+          Tinny is full of creativity, loving art and music. She enjoys dancing and playing the piano, with rich imagination and delicate emotions.
+        </p>
+      )
+    },
+    kelly: {
+      zh: (
+        <p>
+          Kelly活泼可爱，才3岁，充满好奇心。她最喜欢和姐姐妈妈玩，总是用她天真的笑容感染着全家人。
+        </p>
+      ),
+      en: (
+        <p>
+          Kelly is lively and adorable, only 3 years old, full of curiosity. She loves playing with her sister and mother, always infecting the whole family with her innocent smile.
+        </p>
+      )
+    }
+  } as const;
+
+  const familyMembers = [
+    {
+      key: 'dash',
+      name: texts.dash.name[language],
+      title: texts.dash.title[language],
+      description: familyDescriptions.dash[language],
+      imageSrc: photos.dash,
+      orientation: 'horizontal' as const,
+      imagePosition: 'left' as const,
+      className: styles.horizontalCard
+    },
+    {
+      key: 'cherry',
+      name: texts.cherry.name[language],
+      title: texts.cherry.title[language],
+      description: familyDescriptions.cherry[language],
+      imageSrc: photos.cherry,
+      orientation: 'horizontal' as const,
+      imagePosition: 'right' as const,
+      className: styles.horizontalCard
+    },
+    {
+      key: 'jimmy',
+      name: texts.jimmy.name[language],
+      title: texts.jimmy.title[language],
+      description: familyDescriptions.jimmy[language],
+      imageSrc: photos.jimmy,
+      orientation: 'vertical' as const
+    },
+    {
+      key: 'tinny',
+      name: texts.tinny.name[language],
+      title: texts.tinny.title[language],
+      description: familyDescriptions.tinny[language],
+      imageSrc: photos.tinny,
+      orientation: 'vertical' as const
+    },
+    {
+      key: 'kelly',
+      name: texts.kelly.name[language],
+      title: texts.kelly.title[language],
+      description: familyDescriptions.kelly[language],
+      imageSrc: photos.kelly,
+      orientation: 'vertical' as const
+    }
+  ] as const;
+
   useEffect(() => {
     async function fetchPhotos() {
-      // 如果已经加载过照片，就不再重复加载
       if (photosLoadedRef.current) return;
-      
+
       setIsLoading(true);
       try {
         const data = await getPhotoPathsClient();
-        // 将标准格式和HEIC格式的照片合并
         const allPhotos = [...data.standard, ...data.heic];
-        // 随机选择8张照片
         const selected = getRandomPhotos(allPhotos, 8);
         setRandomPhotos(selected);
-        // 标记已加载过照片
         photosLoadedRef.current = true;
       } catch (error) {
-        console.error("获取照片错误:", error);
-        // 如果API调用失败，使用默认照片
+        console.error('获取照片错误:', error);
         setRandomPhotos(photos.gallery);
-        // 标记已加载过照片
         photosLoadedRef.current = true;
       } finally {
         setIsLoading(false);
       }
     }
-    
+
     fetchPhotos();
   }, []);
 
   return (
-    <div style={{ 
-      backgroundColor: colors.mint,
-      minHeight: '100vh',
-      fontFamily: '"Times New Roman", serif',
-      color: colors.darkText,
-      padding: '0',
-      margin: '0'
-    }}>
-      {/* 语言切换按钮 */}
-      <button 
-        onClick={toggleLanguage}
-        style={{
-          position: 'fixed',
-          top: '2rem',
-          right: '2rem',
-          padding: '0.5rem 1rem',
-          backgroundColor: 'rgba(255, 255, 255, 0.7)',
-          border: 'none',
-          borderRadius: '4px',
-          fontSize: '0.9rem',
-          cursor: 'pointer',
-          zIndex: 100,
-          boxShadow: '0 2px 5px rgba(0,0,0,0.1)',
-          transition: 'all 0.3s ease'
-        }}
-      >
+    <div className={styles.page}>
+      <button className={styles.languageSwitch} onClick={toggleLanguage}>
         {texts.languageSwitch[language]}
       </button>
 
-      {/* 主页块 */}
-      <section style={{
-        position: 'relative',
-        minHeight: '100vh',
-        backgroundColor: colors.mint,
-        overflow: 'hidden'
-      }}>
-        <div style={{
-          position: 'relative',
-          width: '100%',
-          height: '100vh',
-          display: 'flex',
-          alignItems: 'center'
-        }}>
-          <div style={{
-            display: 'flex',
-            flexDirection: 'row',
-            flexWrap: 'wrap',
-            margin: '0 auto',
-            width: '90%',
-            maxWidth: '1600px',
-            height: 'auto',
-            minHeight: '75vh',
-            boxShadow: '0 10px 30px rgba(0,0,0,0.05)',
-            boxSizing: 'border-box'
-          }}>
-            {/* 左侧照片 */}
-            <div style={{
-              flex: '8',
-              minWidth: '300px',
-              position: 'relative',
-              overflow: 'hidden',
-              minHeight: '300px'
-            }}>
-              <Image 
+      <section className={styles.heroSection}>
+        <div className={styles.heroInner}>
+          <div className={styles.heroWrapper}>
+            <div className={styles.heroImage}>
+              <Image
                 src={photos.hero}
                 alt="家庭照片"
                 fill
-                style={{ objectFit: 'cover' }}
                 priority
+                sizes="(min-width: 1280px) 50vw, (min-width: 768px) 60vw, 100vw"
               />
             </div>
-
-            {/* 右侧内容 */}
-            <div style={{
-              backgroundColor: colors.white,
-              flex: '5',
-              minWidth: '300px',
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-              padding: 'clamp(2rem, 5vw, 5rem)',
-              position: 'relative',
-              boxSizing: 'border-box'
-            }}>
-              <div style={{
-                position: 'relative',
-                padding: '2rem 0'
-              }}>
-                <div style={{
-                  position: 'relative',
-                  marginBottom: '2rem'
-                }}>
-                  {/* 使用自定义div替代h1来避免任何默认样式 */}
-                  <div style={{
-                    fontWeight: '300',
-                    margin: '0',
-                    padding: '0',
-                    border: 'none',
-                    textDecoration: 'none'
-                  }}>
-                    <div style={{
-                      display: 'block',
-                      fontSize: 'clamp(4rem, 6vw, 7rem)',
-                      fontWeight: '300',
-                      margin: '0 0 0.5rem',
-                      lineHeight: '1.2',
-                      color: colors.darkText,
-                      fontFamily: '"造字工房朗宋", "汉仪瑞兽", "FZLangSong", "华文隶书", "LiSu", serif',
-                      letterSpacing: '0.05em',
-                      textDecoration: 'none',
-                      border: 'none'
-                    }}>
-                      黄
-                    </div>
-                    <div style={{ 
-                      display: 'block',
-                      fontSize: 'clamp(2.5rem, 4vw, 4.5rem)', 
-                      fontWeight: '300',
-                      opacity: 0.7,
-                      color: colors.darkText,
-                      fontFamily: '"Cinzel", "Trajan Pro", "Times New Roman", serif',
-                      fontStyle: 'italic',
-                      letterSpacing: '0.08em',
-                      textDecoration: 'none',
-                      border: 'none'
-                    }}>
-                      Huang
-                    </div>
-                  </div>
+            <div className={styles.heroContent}>
+              <div className={styles.heroText}>
+                <div className={styles.heroTitle}>
+                  <span className={styles.heroTitlePrimary}>黄</span>
+                  <span className={styles.heroTitleSecondary}>Huang</span>
                 </div>
-                <div style={{
-                  marginTop: '2rem',
-                  fontSize: 'clamp(1rem, 1.3vw, 1.3rem)',
-                  lineHeight: '1.8',
-                  letterSpacing: '0.02em',
-                  color: colors.darkText,
-                  maxWidth: '600px'
-                }} 
-                  dangerouslySetInnerHTML={{ __html: texts.homeIntro[language] }}
-                />
-                
-                {/* 浏览家庭链接 */}
-                <a href="#family" style={{
-                  display: 'inline-block',
-                  marginTop: '1rem',
-                  color: colors.darkText,
-                  textDecoration: 'none',
-                  borderBottom: `1px solid ${colors.darkText}`,
-                  paddingBottom: '0.25rem',
-                  fontSize: '0.9rem',
-                  letterSpacing: '1px',
-                  textTransform: 'uppercase'
-                }}>
+                <p className={styles.heroDescription}>{texts.homeIntro[language]}</p>
+                <a className={styles.textLink} href="#family">
                   {texts.exploreFamily[language]}
                 </a>
               </div>
@@ -427,390 +394,53 @@ export default function Home() {
         </div>
       </section>
 
-      {/* 家庭成员部分 */}
-      <section id="family" style={{
-        padding: '15vh 0'
-      }}>
-        <div style={{
-          margin: '0 auto',
-          width: '90%',
-          maxWidth: '1600px'
-        }}>
-          <h2 style={{
-            fontSize: 'clamp(2.5rem, 5vw, 4rem)',
-            fontWeight: '300',
-            marginBottom: '5rem',
-            textAlign: 'center',
-            color: colors.darkText
-          }}>{texts.familyMembers[language]}</h2>
-
-          {/* Dash 块 */}
-          <div style={{
-            display: 'flex',
-            flexDirection: 'row',
-            flexWrap: 'wrap',
-            marginBottom: '8rem',
-            boxShadow: '0 10px 30px rgba(0,0,0,0.05)'
-          }}>
-            {/* 左侧照片 */}
-            <div style={{
-              backgroundColor: colors.sand,
-              flex: '1',
-              minWidth: '300px',
-              minHeight: '400px',
-              position: 'relative',
-              overflow: 'hidden'
-            }}>
-              <Image 
-                src={photos.dash}
-                alt={texts.dash.name[language]}
-                fill
-                style={{ objectFit: 'cover' }}
+      <section id="family" className={styles.familySection}>
+        <div className={styles.sectionContainer}>
+          <h2 className={styles.sectionTitle}>{texts.familyMembers[language]}</h2>
+          <div className={styles.familyGrid}>
+            {familyMembers.map(member => (
+              <FamilyMemberCard
+                key={member.key}
+                name={member.name}
+                title={member.title}
+                description={member.description}
+                imageSrc={member.imageSrc}
+                orientation={member.orientation}
+                imagePosition={member.imagePosition}
+                className={member.className}
               />
-            </div>
-            {/* 右侧内容 */}
-            <div style={{
-              backgroundColor: colors.white,
-              flex: '1',
-              minWidth: '300px',
-              padding: '4rem',
-              position: 'relative'
-            }}>
-              <h3 style={{
-                fontSize: 'clamp(2rem, 3vw, 2.5rem)',
-                fontWeight: '300',
-                marginBottom: '1.5rem',
-                color: colors.darkText
-              }}>{texts.dash.name[language]}</h3>
-              <div style={{
-                width: '50px',
-                height: '2px',
-                backgroundColor: colors.sand,
-                marginBottom: '2rem'
-              }}></div>
-              <p 
-                style={{
-                  fontSize: '1.1rem',
-                  lineHeight: '1.8',
-                  color: colors.lightText,
-                  marginBottom: '1.5rem'
-                }}
-                dangerouslySetInnerHTML={{ __html: texts.dash.desc[language] }}
-              >
-              </p>
-            </div>
+            ))}
           </div>
 
-          {/* Cherry 块 */}
-          <div style={{
-            display: 'flex',
-            flexDirection: 'row-reverse',
-            flexWrap: 'wrap',
-            marginBottom: '8rem',
-            boxShadow: '0 10px 30px rgba(0,0,0,0.05)'
-          }}>
-            {/* 右侧照片 */}
-            <div style={{
-              backgroundColor: colors.sand,
-              flex: '1',
-              minWidth: '300px',
-              minHeight: '400px',
-              position: 'relative',
-              overflow: 'hidden'
-            }}>
-              <Image 
-                src={photos.cherry}
-                alt={texts.cherry.name[language]}
-                fill
-                style={{ objectFit: 'cover' }}
-              />
-            </div>
-            {/* 左侧内容 */}
-            <div style={{
-              backgroundColor: colors.white,
-              flex: '1',
-              minWidth: '300px',
-              padding: '4rem',
-              position: 'relative'
-            }}>
-              <h3 style={{
-                fontSize: 'clamp(2rem, 3vw, 2.5rem)',
-                fontWeight: '300',
-                marginBottom: '1.5rem',
-                color: colors.darkText
-              }}>{texts.cherry.name[language]}</h3>
-              <div style={{
-                width: '50px',
-                height: '2px',
-                backgroundColor: colors.sand,
-                marginBottom: '2rem'
-              }}></div>
-              <p style={{
-                fontSize: '1.1rem',
-                lineHeight: '1.8',
-                color: colors.lightText,
-                marginBottom: '1.5rem'
-              }}>
-                {texts.cherry.desc[language]}
-              </p>
-            </div>
-          </div>
-
-          {/* 孩子们块 - 并排展示 */}
-          <div style={{
-            display: 'flex',
-            flexDirection: 'row',
-            flexWrap: 'wrap',
-            gap: '2rem',
-            marginBottom: '8rem'
-          }}>
-            {/* Jimmy 模块 */}
-            <div style={{
-              flex: '1',
-              minWidth: '300px',
-              display: 'flex',
-              flexDirection: 'column',
-              boxShadow: '0 10px 30px rgba(0,0,0,0.05)'
-            }}>
-              {/* 上方照片 */}
-              <div style={{
-                backgroundColor: colors.sand,
-                minHeight: '300px',
-                position: 'relative',
-                overflow: 'hidden'
-              }}>
-                <Image 
-                  src={photos.jimmy}
-                  alt={texts.jimmy.name[language]}
-                  fill
-                  style={{ objectFit: 'cover' }}
-                />
-              </div>
-              {/* 下方内容 */}
-              <div style={{
-                backgroundColor: colors.white,
-                padding: '3rem',
-                flex: '1'
-              }}>
-                <h3 style={{
-                  fontSize: 'clamp(1.5rem, 2vw, 2rem)',
-                  fontWeight: '300',
-                  marginBottom: '1rem',
-                  color: colors.darkText
-                }}>{texts.jimmy.name[language]}</h3>
-                <div style={{
-                  width: '30px',
-                  height: '2px',
-                  backgroundColor: colors.sand,
-                  marginBottom: '1.5rem'
-                }}></div>
-                <p style={{
-                  fontSize: '1rem',
-                  lineHeight: '1.8',
-                  color: colors.lightText,
-                  marginBottom: '1rem'
-                }}>
-                  {texts.jimmy.title[language]}
-                </p>
-                <p style={{
-                  fontSize: '1rem',
-                  lineHeight: '1.8',
-                  color: colors.lightText
-                }}>
-                  {texts.jimmy.desc[language]}
-                </p>
-              </div>
-            </div>
-
-            {/* Tinny 模块 */}
-            <div style={{
-              flex: '1',
-              minWidth: '300px',
-              display: 'flex',
-              flexDirection: 'column',
-              boxShadow: '0 10px 30px rgba(0,0,0,0.05)'
-            }}>
-              {/* 上方照片 */}
-              <div style={{
-                backgroundColor: colors.sand,
-                minHeight: '300px',
-                position: 'relative',
-                overflow: 'hidden'
-              }}>
-                <Image 
-                  src={photos.tinny}
-                  alt={texts.tinny.name[language]}
-                  fill
-                  style={{ objectFit: 'cover' }}
-                />
-              </div>
-              {/* 下方内容 */}
-              <div style={{
-                backgroundColor: colors.white,
-                padding: '3rem',
-                flex: '1'
-              }}>
-                <h3 style={{
-                  fontSize: 'clamp(1.5rem, 2vw, 2rem)',
-                  fontWeight: '300',
-                  marginBottom: '1rem',
-                  color: colors.darkText
-                }}>{texts.tinny.name[language]}</h3>
-                <div style={{
-                  width: '30px',
-                  height: '2px',
-                  backgroundColor: colors.sand,
-                  marginBottom: '1.5rem'
-                }}></div>
-                <p style={{
-                  fontSize: '1rem',
-                  lineHeight: '1.8',
-                  color: colors.lightText,
-                  marginBottom: '1rem'
-                }}>
-                  {texts.tinny.title[language]}
-                </p>
-                <p style={{
-                  fontSize: '1rem',
-                  lineHeight: '1.8',
-                  color: colors.lightText
-                }}>
-                  {texts.tinny.desc[language]}
-                </p>
-              </div>
-            </div>
-
-            {/* Kelly 模块 */}
-            <div style={{
-              flex: '1',
-              minWidth: '300px',
-              display: 'flex',
-              flexDirection: 'column',
-              boxShadow: '0 10px 30px rgba(0,0,0,0.05)'
-            }}>
-              {/* 上方照片 */}
-              <div style={{
-                backgroundColor: colors.sand,
-                minHeight: '300px',
-                position: 'relative',
-                overflow: 'hidden'
-              }}>
-                <Image 
-                  src={photos.kelly}
-                  alt={texts.kelly.name[language]}
-                  fill
-                  style={{ objectFit: 'cover' }}
-                />
-              </div>
-              {/* 下方内容 */}
-              <div style={{
-                backgroundColor: colors.white,
-                padding: '3rem',
-                flex: '1'
-              }}>
-                <h3 style={{
-                  fontSize: 'clamp(1.5rem, 2vw, 2rem)',
-                  fontWeight: '300',
-                  marginBottom: '1rem',
-                  color: colors.darkText
-                }}>{texts.kelly.name[language]}</h3>
-                <div style={{
-                  width: '30px',
-                  height: '2px',
-                  backgroundColor: colors.sand,
-                  marginBottom: '1.5rem'
-                }}></div>
-                <p style={{
-                  fontSize: '1rem',
-                  lineHeight: '1.8',
-                  color: colors.lightText,
-                  marginBottom: '1rem'
-                }}>
-                  {texts.kelly.title[language]}
-                </p>
-                <p style={{
-                  fontSize: '1rem',
-                  lineHeight: '1.8',
-                  color: colors.lightText
-                }}>
-                  {texts.kelly.desc[language]}
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* 相册预览 */}
-          <div style={{
-            marginBottom: '5rem'
-          }}>
-            <h2 style={{
-              fontSize: 'clamp(2rem, 4vw, 3rem)',
-              fontWeight: '300',
-              marginBottom: '3rem',
-              textAlign: 'center',
-              color: colors.darkText
-            }}>{texts.gallery[language]}</h2>
-            <div style={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
-              gap: '1.5rem'
-            }}>
+          <div className={styles.gallerySection}>
+            <h2 className={styles.galleryTitle}>{texts.gallery[language]}</h2>
+            <div className={styles.galleryGrid}>
               {isLoading ? (
-                // 加载状态
-                <div style={{ 
-                  gridColumn: '1 / -1', 
-                  textAlign: 'center', 
-                  padding: '3rem 0',
-                  color: colors.lightText 
-                }}>
-                  加载照片中...
-                </div>
+                <div className={styles.galleryStatus}>加载照片中...</div>
               ) : randomPhotos.length > 0 ? (
-                // 显示随机照片
                 randomPhotos.map((photo, index) => (
-                  <div key={index} style={{
-                    position: 'relative',
-                    height: '250px',
-                    overflow: 'hidden',
-                    boxShadow: '0 5px 15px rgba(0,0,0,0.1)',
-                    cursor: 'pointer'
-                  }} onClick={() => openLightbox(photo)}>
-                    <Image 
+                  <div
+                    key={photo}
+                    className={styles.galleryItem}
+                    onClick={() => openLightbox(photo)}
+                  >
+                    <Image
                       src={photo}
-                      alt={`家庭照片 ${index+1}`}
+                      alt={`家庭照片 ${index + 1}`}
                       fill
-                      style={{ objectFit: 'cover' }}
-                      priority={index < 4} // 优先加载前4张图片
-                      loading={index < 4 ? "eager" : "lazy"} // 前4张立即加载，其余懒加载
+                      className={styles.galleryImage}
+                      sizes="(min-width: 1280px) 25vw, (min-width: 768px) 33vw, 100vw"
+                      priority={index < 4}
+                      loading={index < 4 ? 'eager' : 'lazy'}
                     />
                   </div>
                 ))
               ) : (
-                // 没有照片时显示
-                <div style={{ 
-                  gridColumn: '1 / -1', 
-                  textAlign: 'center', 
-                  padding: '3rem 0',
-                  color: colors.lightText 
-                }}>
-                  暂无照片可显示
-                </div>
+                <div className={styles.galleryStatus}>暂无照片可显示</div>
               )}
             </div>
-            <div style={{
-              textAlign: 'center',
-              marginTop: '3rem'
-            }}>
-              <Link href="/gallery" style={{
-                display: 'inline-block',
-                color: colors.darkText,
-                textDecoration: 'none',
-                borderBottom: `1px solid ${colors.darkText}`,
-                paddingBottom: '0.25rem',
-                fontSize: '0.9rem',
-                letterSpacing: '1px',
-                textTransform: 'uppercase'
-              }}>
+            <div className={styles.galleryCta}>
+              <Link href="/gallery" className={styles.textLink}>
                 {texts.viewGallery[language]}
               </Link>
             </div>
@@ -818,94 +448,38 @@ export default function Home() {
         </div>
       </section>
 
-      {/* 底部联系我们 */}
-      <section style={{
-        backgroundColor: colors.white,
-        padding: '10vh 0'
-      }}>
-        <div style={{
-          margin: '0 auto',
-          width: '90%',
-          maxWidth: '800px',
-          textAlign: 'center'
-        }}>
-          <p style={{
-            fontSize: '1.2rem',
-            color: colors.lightText,
-            lineHeight: '1.8',
-            marginBottom: '2rem'
-          }}>© 2024 黄 · Huang</p>
+      <section className={styles.footerSection}>
+        <div className={styles.footerContainer}>
+          <p className={styles.footerText}>© 2024 黄 · Huang</p>
         </div>
       </section>
 
-      {/* 灯箱组件 */}
       {lightbox.isOpen && (
-        <div 
-          style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%',
-            backgroundColor: 'rgba(0, 0, 0, 0.9)',
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            zIndex: 1000,
-            cursor: 'zoom-out'
-          }}
-          onClick={closeLightbox}
-        >
-          {/* 关闭按钮 */}
+        <div className={styles.lightboxOverlay} onClick={closeLightbox}>
           <button
-            style={{
-              position: 'absolute',
-              top: '20px',
-              right: '20px',
-              backgroundColor: 'transparent',
-              border: 'none',
-              color: 'white',
-              fontSize: '24px',
-              cursor: 'pointer',
-              zIndex: 1001
+            type="button"
+            className={styles.lightboxClose}
+            onClick={event => {
+              event.stopPropagation();
+              closeLightbox();
             }}
-            onClick={closeLightbox}
           >
             ✕
           </button>
-          
-          {/* 图片容器 */}
           <div
-            style={{
-              maxWidth: '90%',
-              maxHeight: '90%',
-              position: 'relative'
-            }}
-            onClick={(e) => e.stopPropagation()} // 防止点击图片时关闭灯箱
+            className={styles.lightboxContent}
+            onClick={event => event.stopPropagation()}
           >
-            <img
+            <Image
               src={lightbox.currentImage}
               alt="原图"
-              style={{
-                maxWidth: '100%',
-                maxHeight: '90vh',
-                objectFit: 'contain',
-                boxShadow: '0 4px 20px rgba(0, 0, 0, 0.3)',
-                cursor: 'default',
-                // 如果正在加载，则隐藏图片
-                display: lightbox.loading ? 'none' : 'block'
-              }}
-              onLoad={handleImageLoad}
+              fill
+              className={`${styles.lightboxImage} ${lightbox.loading ? styles.hidden : ''}`}
+              sizes="100vw"
+              onLoadingComplete={() => handleImageLoad()}
             />
-            {/* 加载指示器 */}
             {lightbox.loading && (
-              <div style={{ 
-                color: 'white',
-                fontSize: '1.2rem',
-                textAlign: 'center'
-              }}>
-                加载中...
-              </div>
+              <div className={styles.lightboxLoader}>加载中...</div>
             )}
           </div>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -319,7 +319,7 @@ export default function Home() {
       imageSrc: photos.jimmy,
       orientation: 'vertical' as const,
       imagePosition: 'left' as const,
-      className: undefined
+      className: styles.verticalCard
     },
     {
       key: 'tinny',
@@ -329,7 +329,7 @@ export default function Home() {
       imageSrc: photos.tinny,
       orientation: 'vertical' as const,
       imagePosition: 'left' as const,
-      className: undefined
+      className: styles.verticalCard
     },
     {
       key: 'kelly',
@@ -339,7 +339,7 @@ export default function Home() {
       imageSrc: photos.kelly,
       orientation: 'vertical' as const,
       imagePosition: 'left' as const,
-      className: undefined
+      className: styles.verticalCard
     }
   ] as const;
 


### PR DESCRIPTION
## Summary
- add a reusable `FamilyMemberCard` component and supporting styles
- migrate home page layout to a CSS module and render family data via mapping
- refresh the family gallery section and lightbox to use shared styling and Next.js image handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c90c8ff4b0832dad8a6703cd2ae4f1